### PR TITLE
Rename github to remotes

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -44,15 +44,15 @@
         },
         "cran": {
           "type": "string",
-          "description": "[FUTURE RELEASE] list of packages to install from CRAN, each separated by a space(RStudio Server only)"
+          "description": "List of packages to install from CRAN, each separated by a space(RStudio Server only)"
         },
-        "github": {
+        "remotes": {
           "type": "string",
-          "description": "[FUTURE RELEASE] packages to install from GitHub, each separated by a space (RStudio Server only)"
+          "description": "List of packages to install from GitHub, each separated by a space (RStudio Server only)"
         },
         "bioconductor": {
           "type": "string",
-          "description": "[FUTURE RELEASE] packages to install from Bioconductor, each separated by a space (RStudio Server only)"
+          "description": "List of packages to install from Bioconductor, each separated by a space (RStudio Server only)"
         },
         "use_mamba": {
           "type": "boolean",


### PR DESCRIPTION
2021.11.10 starts allowing r extra packages and changed the name of github to remotes.
