### PR TITLE
Allow version on 2021.11.10

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -259,6 +259,10 @@
       "type": "string",
       "description": "Name of owner. Must refer to an existing user or group within Saturn."
     },
+    "version": {
+      "type": "string",
+      "description": "The version of Saturn Cloud used when creating the recipe."
+    },
     "collaborators": {
       "type": "array",
       "description": "Name of collaborators. Must refer to existing users or groups within Saturn.",


### PR DESCRIPTION
I want to add versions to old releases of recipes, but they aren't allowed on 2021.11.10, so this enables them.