### PR TITLE
Require version

### DIFF
--- a/resources/example.json
+++ b/resources/example.json
@@ -47,5 +47,6 @@
       "type": "environment_variable",
       "location": "SNOWFLAKE_PASSWORD"
     }
-  ]
+  ],
+  "version": "2021.11.10"
 }

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -273,7 +273,8 @@
   },
   "additionalProperties": false,
   "required": [
-    "name"
+    "name",
+    "version"
   ],
   "oneOf": [
     {


### PR DESCRIPTION
This enforces that version be included on every recipe. This seems safest to make sure that we can manage any future compatibility needs.
