### PR TITLE
Changed "version" to "schema_version" in resource recipes

### DIFF
--- a/resources/example.json
+++ b/resources/example.json
@@ -48,5 +48,5 @@
       "location": "SNOWFLAKE_PASSWORD"
     }
   ],
-  "version": "2021.11.10"
+  "schema_version": "2021.11.10"
 }

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -259,9 +259,9 @@
         }
       ]
     },
-    "version": {
+    "schema_version": {
       "type": "string",
-      "description": "The version of Saturn Cloud used when creating the recipe."
+      "description": "The version of the recipe schema used. Typically the same as the Saturn Cloud version used when creating the recipe."
     },
     "public": {
       "type": "boolean",

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -272,7 +272,7 @@
   "additionalProperties": false,
   "required": [
     "name",
-    "version"
+    "schema_version"
   ],
   "oneOf": [
     {


### PR DESCRIPTION
This is to account for the fact that version conflicts with _image_ version, and just to make it more clear of a term in general.