### PR TITLE
Make template just a resource recipe

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -259,6 +259,14 @@
         }
       ]
     },
+    "thumbnail_image_url": {
+      "type": "string",
+      "description": "[FUTURE RELEASE] Publicly accessible URL of a picture to use as a thumbnail for the resource."
+    },
+    "priority": {
+      "type": "integer",
+      "description": "[FUTURE RELEASE] The relative priority to use when displaying lists of resources. Lower numbers appear earlier in lists."
+    },
     "version": {
       "type": "string",
       "description": "The version of Saturn Cloud used when creating the recipe."


### PR DESCRIPTION
The idea in this PR is to make it so that the recipe for a template can just be a resource recipe. To apply a bunch of templates you would pass a set to `/api/recipes/apply` with `templates={list of recipes}`