### PR TITLE
Make version a constant

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -260,7 +260,7 @@
       ]
     },
     "version": {
-      "type": "string",
+      "const": "2022.01.06",
       "description": "The version of Saturn Cloud used when creating the recipe."
     },
     "collaborators": {

--- a/sets/schema.json
+++ b/sets/schema.json
@@ -12,7 +12,7 @@
       "description": "Details about the set of recipes."
     },
     "version": {
-      "type": "string",
+      "const": "2022.01.06",
       "description": "The version of Saturn Cloud used when creating the set of recipes."
     },
     "resources": {


### PR DESCRIPTION
I was going back and forth on this, but basically this ensures that the version field has to be exactly the version of the schema for validation to work. 