### PR TITLE
Added a category to templates

### DIFF
--- a/templates/schema.json
+++ b/templates/schema.json
@@ -11,9 +11,12 @@
       "type": "string",
       "description": "Longer description of the template."
     },
-    "category": {
-      "type": "string",
-      "description": "[FUTURE RELEASE] Optional category to use when showing a list of templates."
+    "labels": {
+      "type": "array",
+      "description": "[FUTURE RELEASE] Optional labels to use when to categorize templates.",
+      "items": {
+        "type": "string"
+      }
     },
     "thumbnail_image_url": {
       "type": "string",

--- a/templates/schema.json
+++ b/templates/schema.json
@@ -13,7 +13,7 @@
     },
     "category": {
       "type": "string",
-      "description": "Optional category to use when showing a list of templates."
+      "description": "[FUTURE RELEASE] Optional category to use when showing a list of templates."
     },
     "thumbnail_image_url": {
       "type": "string",

--- a/templates/schema.json
+++ b/templates/schema.json
@@ -11,6 +11,10 @@
       "type": "string",
       "description": "Longer description of the template."
     },
+    "category": {
+      "type": "string",
+      "description": "Optional category to use when showing a list of templates."
+    },
     "thumbnail_image_url": {
       "type": "string",
       "description": "Publicly accessible url containing an image to use as the thumbnail. Image should be 500px wide by 250px high."


### PR DESCRIPTION
Our list of templates is getting long and difficult for users to parse. As part of @dotNomad's work in redoing the "create from template" flow, I think it would be a good idea to have the template broken down into categories, like:

* Production (jobs, apis, dashboards)
* Deep learning (PyTorch, Tensorflow)
* Parallel (dask, future)

And so on.

I also considered adding a separate "language" for further filtering, but I think that's overkill for now. I also made this an optional parameter, so like for enterprise customers they don't have to categorize if they don't want to.