### PR TITLE
Give extra package types metadata

### DIFF
--- a/resources/example.json
+++ b/resources/example.json
@@ -3,7 +3,7 @@
   "description": "A demonstration of the saturn.json schema",
   "image_uri": "saturncloud/saturn:2021.11.10",
   "extra_packages": {
-    "conda": "tensorflow==2.6.0 papermill"
+    "conda": {"packages": "tensorflow==2.6.0 papermill", "use_mamba": false}
   },
   "environment_variables": {
     "VAR1": "VALUE1",

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -101,7 +101,7 @@
             },
             "repo": {
               "type": "string",
-              "description": "[FUTURE RELEASE] URL of a CRAN mirror to use with the repo. If not specified defaults to the result of `getOption("repos")` run on the image.",
+              "description": "[FUTURE RELEASE] URL of a CRAN mirror to use with the repo. If not specified defaults to the result of `getOption(\"repos\")` run on the image."
             }
           }
         },
@@ -115,7 +115,7 @@
               "examples": ["rstudio/tensorflow r-lib/r-oxygen2"]
             },
             "remote": {
-              "type": "enum",
+              "type": "string",
               "description": "[FUTURE RELEASE] Location to pull the remote from.",
               "enum": [
                 "github",

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -56,33 +56,88 @@
       "description": "extra packages to install. Not all of these may exist depending on the resource type and if they are needed",
       "properties": {
         "conda": {
-          "type": "string",
-          "description": "Packages to install from conda"
+          "type": "object",
+          "description": "Packages to install from conda",
+          "properties": {
+            "packages": {
+              "type": "string",
+              "description": "Packages to install from conda. This will be appended to `conda install `, so each package should be separated by a space."
+            },
+            "use_mamba": {
+              "type": "boolean",
+              "description": "Whether to use mamba when installing via conda. Replaces the command with `mamba install`",
+              "default": "true"
+            }
+          }
         },
         "pip": {
-          "type": "string",
-          "description": "Packages to install from pip"
+          "type": "object",
+          "description": "Packages to install from pip",
+          "properties": {
+            "packages": {
+              "type": "string",
+              "description": "Packages to install from pip. This will be appended to `pip install `, so each package should be separated by a space."
+            }
+          }
         },
         "apt": {
-          "type": "string",
-          "description": "Packages to install from apt"
+          "type": "object",
+          "description": "Packages to install from apt",
+          "properties": {
+            "packages": {
+              "type": "string",
+              "description": "Packages to install from apt. This will be appended to `apt-get install `, so each package should be separated by a space."
+            }
+          }
         },
         "cran": {
-          "type": "string",
-          "description": "List of packages to install from CRAN, each separated by a space (RStudio Server only)"
+          "type": "object",
+          "description": "List of packages to install from CRAN (RStudio Server only).",
+          "properties": {
+            "packages": {
+              "type": "string",
+              "description": "Packages to install from CRAN. These should be separated by a space--Saturn Cloud will be convert into an R vector.",
+              "examples": ["tidytext odbc"]
+            },
+            "repo": {
+              "type": "string",
+              "description": "[FUTURE RELEASE] URL of a CRAN mirror to use with the repo. If not specified defaults to the result of `getOption("repos")` run on the image.",
+            }
+          }
         },
         "remotes": {
           "type": "string",
-          "description": "List of packages to install from GitHub, each separated by a space (RStudio Server only)"
+          "description": "List of packages to install from GitHub or other remotes, each separated by a space (RStudio Server only)",
+          "properties": {
+            "packages": {
+              "type": "string",
+              "description": "Packages to install from the remote location. These should be separated by a space.",
+              "examples": ["rstudio/tensorflow r-lib/r-oxygen2"]
+            },
+            "remote": {
+              "type": "enum",
+              "description": "[FUTURE RELEASE] Location to pull the remote from.",
+              "enum": [
+                "github",
+                "gitlab",
+                "url",
+                "git"
+              ],
+              "default": "github"
+            }
+          }
         },
+
         "bioconductor": {
-          "type": "string",
-          "description": "List of packages to install from Bioconductor, each separated by a space (RStudio Server only)"
-        },
-        "use_mamba": {
-          "type": "boolean",
-          "description": "Whether to use mamba when installing via conda.",
-          "default": "true"
+          "type": "object",
+          "description": "List of packages to install from Bioconductor (RStudio Server only)",
+          "properties": {
+            "packages": {
+              "type": "string",
+              "description": "Packages to install, each separated by a space."
+            }
+          },
+          "examples": ["BiocGenerics BiocVersion"]
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
As we expand our R support we'll want to be able to install packages from other locations at startup. This is a good time to rearrange it so that the `use_mamba` field gets folded into conda too.

Now all types of extra packages will switch from being a string to an object which can include extra options.

Before
```
"conda": "papermill tensorflow"
```

After

```
"conda": {"packages": "papermill tensorflow", "use_mamba": false}
```