### PR TITLE
Unset schema version on `main`

### DIFF
--- a/images/example.json
+++ b/images/example.json
@@ -22,5 +22,5 @@
       "image_uri": "772275760547.dkr.ecr.us-west-2.amazonaws.com/saturn-tensorflow-384"
     }
   ],
-  "schema_version": "2022.01.06"
+  "schema_version": "main"
 }

--- a/images/schema.json
+++ b/images/schema.json
@@ -114,7 +114,7 @@
       ]
     },
     "schema_version": {
-      "const": "2022.01.06",
+      "const": "main",
       "description": "The version of the schema used. Typically associated with a Saturn Cloud version"
     }
   },

--- a/resources/example.json
+++ b/resources/example.json
@@ -59,5 +59,5 @@
       "location": "SNOWFLAKE_PASSWORD"
     }
   ],
-  "schema_version": "2022.01.06"
+  "schema_version": "main"
 }

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -310,7 +310,7 @@
       ]
     },
     "schema_version": {
-      "const": "2022.01.06",
+      "const": "main",
       "description": "The version of the recipe schema used. Typically the same as the Saturn Cloud version used when creating the recipe."
     },
     "visibility": {

--- a/sets/example.json
+++ b/sets/example.json
@@ -9,7 +9,7 @@
           "image_uri": "saturncloud/saturn:2021.11.10"
         }
       ],
-      "schema_version": "2022.01.06"
+      "schema_version": "main"
     },
     {
       "name": "saturn-rstudio",
@@ -21,7 +21,7 @@
           "image_uri": "saturncloud/saturn-rstudio:2021.11.10"
         }
       ],
-      "schema_version": "2022.01.06"
+      "schema_version": "main"
     }
   ],
   "templates": [
@@ -30,7 +30,7 @@
       "weight": 100,
       "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/rstudio.png",
       "resource": {
-        "schema_version": "2022.01.06",
+        "schema_version": "main",
         "name": "my-rstudio-server",
         "image_uri": "saturncloud/saturn-rstudio:2021.11.10",
         "description": "An RStudio server.",
@@ -38,12 +38,12 @@
           "instance_type": "medium"
         }
       },
-      "schema_version": "2022.01.06"
+      "schema_version": "main"
     }
   ],
   "resources": [
     {
-      "schema_version": "2022.01.06",
+      "schema_version": "main",
       "name": "my-jupyter-server",
       "description": "A demonstration of the saturn.json schema",
       "image_uri": "saturncloud/saturn:2021.11.10",
@@ -95,7 +95,7 @@
       ]
     },
     {
-      "schema_version": "2022.01.06",
+      "schema_version": "main",
       "name": "my-rstudio-server",
       "image_uri": "saturncloud/saturn-rstudio:2021.11.10",
       "description": "An RStudio server.",
@@ -104,7 +104,7 @@
       }
     },
     {
-      "schema_version": "2022.01.06",
+      "schema_version": "main",
       "name": "my-dashboard",
       "image_uri": "saturncloud/saturn:2021.11.10",
       "description": "A dashboard deployment.",
@@ -115,7 +115,7 @@
       }
     },
     {
-      "schema_version": "2022.01.06",
+      "schema_version": "main",
       "name": "a-scheduled-job",
       "image_uri": "saturncloud/saturn:2021.11.10",
       "description": "A job with a schedule.",
@@ -138,5 +138,5 @@
       }
     }
   ],
-  "schema_version": "2022.01.06"
+  "schema_version": "main"
 }

--- a/sets/schema.json
+++ b/sets/schema.json
@@ -12,7 +12,7 @@
       "description": "Details about the set of recipes."
     },
     "schema_version": {
-      "const": "2022.01.06",
+      "const": "main",
       "description": "The version of Saturn Cloud used when creating the set of recipes."
     },
     "resources": {

--- a/templates/example.json
+++ b/templates/example.json
@@ -28,7 +28,7 @@
         "instance_type": "large"
       }
     },
-    "schema_version": "2022.01.06"
+    "schema_version": "main"
   },
-  "schema_version": "2022.01.06"
+  "schema_version": "main"
 }

--- a/templates/schema.json
+++ b/templates/schema.json
@@ -23,7 +23,7 @@
       "$ref": "/resources/schema.json"
     },
     "schema_version": {
-      "const": "2022.01.06",
+      "const": "main",
       "description": "The version of Saturn Cloud used when creating the set of recipes."
     }
   },


### PR DESCRIPTION
Main doesn't really contain the `schema_version` that it purports to match. So this PR proposes updating all `schema_version` fields to `main` and changing all of them will be part of the release process for this repo. 