### PR TITLE
Explicit naming for IDE support

### DIFF
--- a/images/example.json
+++ b/images/example.json
@@ -4,7 +4,7 @@
   "owner": "jnolis",
   "visibility": "owner",
   "hardware_type": "cpu",
-  "supports": ["rstudio", "jupyter"],
+  "supports": ["rstudio-community", "jupyterlab"],
   "versions": [
     {
       "name": "2022.01.06",

--- a/images/schema.json
+++ b/images/schema.json
@@ -38,8 +38,9 @@
         {
           "type": "string",
           "enum": [
-            "rstudio",
-            "jupyter",
+            "rstudio-community",
+            "rstudio-workbench",
+            "jupyterlab",
             "dask"
           ]
         }

--- a/sets/example.json
+++ b/sets/example.json
@@ -13,7 +13,7 @@
     },
     {
       "name": "saturn-rstudio",
-      "supports": ["dask", "rstudio"],
+      "supports": ["dask", "rstudio-community"],
       "hardware_type": "cpu",
       "versions": [
         {


### PR DESCRIPTION
This PR makes the naming in the image schema more explicit:

* `rstudio` is split into `rstudio-community` and `rstudio-workbench` - these work differently and must be supported differently by Saturn, so we need to know which an image supports.
* `jupyter` - renamed to `jupyterlab` explicitly.
