### PR TITLE
Add start_ssh to deployments, update workspace to json schema format

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -211,7 +211,8 @@
         "disk_space": { "$ref": "#/$defs/disk_space" },
         "auto_shutoff": { "$ref": "#/$defs/auto_shutoff" },
         "use_spot_instance": { "$ref": "#/$defs/use_spot_instance" }
-      }
+      },
+      "additionalProperties": false
     },
     "rstudio_server": {
       "type": "object",
@@ -220,7 +221,8 @@
         "start_ssh": { "$ref": "#/$defs/start_ssh" },
         "disk_space": { "$ref": "#/$defs/disk_space" },
         "auto_shutoff": { "$ref": "#/$defs/auto_shutoff" }
-      }
+      },
+      "additionalProperties": false
     },
     "job": {
       "type": "object",


### PR DESCRIPTION
<!-- What is this change, and why is it needed? -->

Adding start_ssh to deployments (functionality added in this PR https://github.com/saturncloud/saturn/pull/4275)

Also noticed that the workspace types were missing the type/properties style definition. Not sure if that's a bug or if it doesn't matter, but looked like all the others were defined following this pattern so I updated them.