### PR TITLE
Fix PR from release action

### DIFF
--- a/.github/workflows/update-main-from-release.yml
+++ b/.github/workflows/update-main-from-release.yml
@@ -4,7 +4,7 @@ name: Release -> Main PR
 
 on:
   push:
-    branches: "release-*"
+    branches: "20*"
 
 jobs:
   pull-request:


### PR DESCRIPTION
On this repo, the release branches don't start with release, they are just the version number, `20*` matches the branch protections in github.
