### PR TITLE
Add conda environment and pip requirements to extra_packages

### DIFF
--- a/resources/example.json
+++ b/resources/example.json
@@ -3,8 +3,7 @@
   "description": "A demonstration of the saturn.json schema",
   "image_uri": "public.ecr.aws/saturncloud/saturn:2022.04.01",
   "extra_packages": {
-    "conda": {"install": "tensorflow==2.6.0 papermill", "use_mamba": false},
-    "pip": {"requirements_txt": "click\nnumba\n"}
+    "conda": {"install": "tensorflow==2.6.0 papermill", "use_mamba": false}
   },
   "environment_variables": {
     "VAR1": "VALUE1",
@@ -38,5 +37,5 @@
       "reference": "dev"
     }
   ],
-  "schema_version": "2022.07.01"
+  "schema_version": "2022.05.01"
 }

--- a/resources/example.json
+++ b/resources/example.json
@@ -1,9 +1,10 @@
 {
   "name": "demo",
   "description": "A demonstration of the saturn.json schema",
-  "image_uri": "public.ecr.aws/saturncloud/saturn:2022.01.06",
+  "image_uri": "public.ecr.aws/saturncloud/saturn:2022.04.01",
   "extra_packages": {
-    "conda": {"install": "tensorflow==2.6.0 papermill", "use_mamba": false}
+    "conda": {"install": "tensorflow==2.6.0 papermill", "use_mamba": false},
+    "pip": {"requirements_txt": "click\nnumba\n"}
   },
   "environment_variables": {
     "VAR1": "VALUE1",
@@ -37,5 +38,5 @@
       "reference": "dev"
     }
   ],
-  "schema_version": "2022.05.01"
+  "schema_version": "2022.07.01"
 }

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -65,7 +65,7 @@
             },
             "environment_yml": {
               "type": "string",
-              "description": "Contents of an conda environment.yml file describing a conda environment. Such as the output of `conda env export`."
+              "description": "[FUTURE RELEASE] Contents of an conda environment.yml file describing a conda environment. Such as the output of `conda env export`."
             },
             "use_mamba": {
               "type": "boolean",
@@ -95,7 +95,7 @@
             },
             "requirements_txt": {
               "type": "string",
-              "description": "Contents of a pip requirements.txt file describing the packages to install with pip. Such as the output of `pip freeze`."
+              "description": "[FUTURE RELEASE] Contents of a pip requirements.txt file describing the packages to install with pip. Such as the output of `pip freeze`."
             }
           },
           "oneOf": [

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -53,15 +53,19 @@
     },
     "extra_packages": {
       "type": "object",
-      "description": "extra packages to install. Not all of these may exist depending on the resource type and if they are needed",
+      "description": "Extra packages to install. Not all of these may exist depending on the resource type and if they are needed",
       "properties": {
         "conda": {
           "type": "object",
-          "description": "Packages to install from conda",
+          "description": "Packages to install with conda",
           "properties": {
             "install": {
               "type": "string",
-              "description": "Packages to install from conda. This will be appended to `conda install `, so each package should be separated by a space."
+              "description": "Packages to install with conda. This will be appended to `conda install `, so each package should be separated by a space."
+            },
+            "environment_yml": {
+              "type": "string",
+              "description": "Contents of an conda environment.yml file describing a conda environment. Such as the output of `conda env export`."
             },
             "use_mamba": {
               "type": "boolean",
@@ -69,19 +73,41 @@
               "default": "true"
             }
           },
-          "required": ["install"],
+          "oneOf": [
+            {
+              "type": "object",
+              "required": ["install"]
+            },
+            {
+              "type": "object",
+              "required": ["environment_yml"]
+            }
+          ],        
           "additionalProperties": false
         },
         "pip": {
           "type": "object",
-          "description": "Packages to install from pip",
+          "description": "Packages to install with pip",
           "properties": {
             "install": {
               "type": "string",
-              "description": "Packages to install from pip. This will be appended to `pip install `, so each package should be separated by a space."
+              "description": "Packages to install with pip. This will be appended to `pip install `, so each package should be separated by a space."
+            },
+            "requirements_txt": {
+              "type": "string",
+              "description": "Contents of a pip requirements.txt file describing the packages to install with pip. Such as the output of `pip freeze`."
             }
           },
-          "required": ["install"],
+          "oneOf": [
+            {
+              "type": "object",
+              "required": ["install"]
+            },
+            {
+              "type": "object",
+              "required": ["requirements_txt"]
+            }
+          ],  
           "additionalProperties": false
         },
         "apt": {


### PR DESCRIPTION
Allow `environment_yml` and `requirements_yml` instead of  `install`.
