### PR TITLE
Use nested image in resource recipe

### DIFF
--- a/images/schema.json
+++ b/images/schema.json
@@ -20,7 +20,8 @@
       "description": "Who should be allowed to use the image.",
       "enum": [
         "owner",
-        "org"
+        "org",
+        "account"
       ]
     },
     "hardware_type": {

--- a/resources/example.json
+++ b/resources/example.json
@@ -1,7 +1,11 @@
 {
   "name": "demo",
   "description": "A demonstration of the saturn.json schema",
-  "image_uri": "public.ecr.aws/saturncloud/saturn:2022.01.06",
+  "image": {
+    "owner": "saturncloud",
+    "name": "saturn",
+    "version": "2022.05.01"
+  },
   "extra_packages": {
     "conda": {"install": "tensorflow==2.6.0 papermill", "use_mamba": false}
   },

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -16,13 +16,9 @@
       "type": "string",
       "description": "Details about the resource, to help distinguish them."
     },
-    "image_uri": {
-      "type": "string",
-      "description": "The URI of the image to use with the resource. The image must exist in the particular Saturn Cloud installation for the resource to work (either Hosted or a particular Enterprise installation)"
-    },
     "image": {
       "type": "object",
-      "description": "[FUTURE RELEASE] The image to use with the resource. The image must exist in the particular Saturn Cloud installation for the resource to work (either Hosted or a particular Enterprise installation)",
+      "description": "The image to use with the resource. The image must exist in the particular Saturn Cloud installation for the resource to work (either Hosted or a particular Enterprise installation)",
       "properties": {
         "owner": {
           "type": "string",
@@ -31,12 +27,12 @@
         "name": {
           "type": "string",
           "description": "The name of the image.",
-          "pattern": "^[-a-zA-Z0-9]+$"
+          "pattern": "^[-a-zA-Z0-9\\.]+$"
         },
         "version": {
           "type": "string",
           "description": "The version of the image.",
-          "pattern": "^[-a-zA-Z0-9]+$"
+          "pattern": "^[-a-zA-Z0-9\\.]+$"
         }
       },
       "additionalProperties": false,
@@ -408,17 +404,8 @@
   "additionalProperties": false,
   "required": [
     "name",
+    "image",
     "schema_version"
-  ],
-  "oneOf": [
-    {
-      "type": "object",
-      "required": ["image"]
-    },
-    {
-      "type": "object",
-      "required": ["image_uri"]
-    }
   ],
   "anyOf": [
     {"required": ["jupyter_server"]},

--- a/sets/example.json
+++ b/sets/example.json
@@ -2,7 +2,9 @@
   "images": [
     {
       "name": "saturn",
+      "owner": "saturncloud",
       "hardware_type": "cpu",
+      "visibility": "account",
       "versions": [
         {
           "name": "2021.11.10",
@@ -13,8 +15,10 @@
     },
     {
       "name": "saturn-rstudio",
+      "owner": "saturncloud",
       "supports": ["dask", "rstudio-opensource"],
       "hardware_type": "cpu",
+      "visibility": "account",
       "versions": [
         {
           "name": "2021.11.10",
@@ -32,7 +36,11 @@
       "resource": {
         "schema_version": "2022.06.01",
         "name": "my-rstudio-server",
-        "image_uri": "saturncloud/saturn-rstudio:2021.11.10",
+        "image": {
+          "owner": "saturncloud",
+          "name": "saturn-rstudio",
+          "version": "2021.11.10"
+        },
         "description": "An RStudio server.",
         "rstudio_server": {
           "instance_type": "medium"
@@ -46,7 +54,11 @@
       "schema_version": "2022.06.01",
       "name": "my-jupyter-server",
       "description": "A demonstration of the saturn.json schema",
-      "image_uri": "saturncloud/saturn:2021.11.10",
+      "image": {
+        "owner": "saturncloud",
+        "name": "saturn",
+        "version": "2021.11.10"
+      },
       "extra_packages": {
         "conda": {"install": "tensorflow==2.6.0 papermill"}
       },
@@ -109,7 +121,11 @@
     {
       "schema_version": "2022.06.01",
       "name": "my-rstudio-server",
-      "image_uri": "saturncloud/saturn-rstudio:2021.11.10",
+      "image": {
+        "owner": "saturncloud",
+        "name": "saturn-rstudio",
+        "version": "2021.11.10"
+      },
       "description": "An RStudio server.",
       "rstudio_server": {
         "instance_type": "medium"
@@ -118,7 +134,11 @@
     {
       "schema_version": "2022.06.01",
       "name": "my-dashboard",
-      "image_uri": "saturncloud/saturn:2021.11.10",
+      "image": {
+        "owner": "saturncloud",
+        "name": "saturn",
+        "version": "2021.11.10"
+      },
       "description": "A dashboard deployment.",
       "deployment": {
         "instance_type": "medium",
@@ -129,7 +149,11 @@
     {
       "schema_version": "2022.06.01",
       "name": "a-scheduled-job",
-      "image_uri": "saturncloud/saturn:2021.11.10",
+      "image": {
+        "owner": "saturncloud",
+        "name": "saturn",
+        "version": "2021.11.10"
+      },
       "description": "A job with a schedule.",
       "environment_variables": {
         "FOO": "bar",

--- a/templates/example.json
+++ b/templates/example.json
@@ -4,7 +4,11 @@
   "weight": 100,
   "resource": {
     "name": "example-dask",
-    "image_uri": "public.ecr.aws/saturncloud/saturn:2022.01.06",
+    "image": {
+      "owner": "saturncloud",
+      "name": "saturn",
+      "version": "2022.05.01"
+    },
     "description": "Use distributed computing with Dask",
     "extra_packages": {
       "pip": {"install": "lightgbm"}


### PR DESCRIPTION
People can have access to multiple images with the same image_uri so it is not enough information to keep track of which image is intended by a particular recipe. So this PR changes it to always use nested image instead.
