### PR TITLE
Add `start_dind` flag to workspaces

### DIFF
--- a/resources/example.json
+++ b/resources/example.json
@@ -18,7 +18,8 @@
     "instance_type": "xlarge",
     "start_ssh": true,
     "disk_space": "10Gi",
-    "auto_shutoff": "1 hour"
+    "auto_shutoff": "1 hour",
+    "start_dind": false
   },
   "dask_cluster": {
     "num_workers": 3,

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -232,7 +232,8 @@
         "start_ssh": { "$ref": "#/$defs/start_ssh" },
         "disk_space": { "$ref": "#/$defs/disk_space" },
         "auto_shutoff": { "$ref": "#/$defs/auto_shutoff" },
-        "use_spot_instance": { "$ref": "#/$defs/use_spot_instance" }
+        "use_spot_instance": { "$ref": "#/$defs/use_spot_instance" },
+        "start_dind": { "$ref": "#/$defs/start_dind" }
       },
       "additionalProperties": false
     },
@@ -242,7 +243,9 @@
         "instance_type": { "$ref": "#/$defs/instance_type" },
         "start_ssh": { "$ref": "#/$defs/start_ssh" },
         "disk_space": { "$ref": "#/$defs/disk_space" },
-        "auto_shutoff": { "$ref": "#/$defs/auto_shutoff" }
+        "auto_shutoff": { "$ref": "#/$defs/auto_shutoff" },
+        "use_spot_instance": { "$ref": "#/$defs/use_spot_instance" },
+        "start_dind": { "$ref": "#/$defs/start_dind" }
       },
       "additionalProperties": false
     },
@@ -461,6 +464,11 @@
     "use_spot_instance": {
       "type": "boolean",
       "description": "Whether the server should use a spot instance",
+      "default": false
+    },
+    "start_dind": {
+      "type": "boolean",
+      "description": "Whether Docker support should be enabled",
       "default": false
     },
     "schedule": {


### PR DESCRIPTION
This PR adds the `start_dind` flag to the specification for workspaces.

Additionally, I noticed `rstudio_server` was missing the `use_spot_instance` flag in its definition - I've added that here as well.